### PR TITLE
Fix pong requests

### DIFF
--- a/loolwsd/LOOLWSD.cpp
+++ b/loolwsd/LOOLWSD.cpp
@@ -218,7 +218,7 @@ void SocketProcessor(std::shared_ptr<WebSocket> ws,
                     // However Firefox (probably) or Node.js (possibly) doesn't
                     // like that and closes the socket when we do.
                     // Echoing the payload as a normal frame works with Firefox.
-                    ws->sendFrame(buffer, n /*, WebSocket::FRAME_OP_PONG*/);
+                    ws->sendFrame(buffer, n, WebSocket::FRAME_FLAG_FIN | WebSocket::FRAME_OP_PONG);
                 }
                 else if ((flags & WebSocket::FRAME_OP_BITMASK) == WebSocket::FRAME_OP_PONG)
                 {


### PR DESCRIPTION
Sorry for creating a PR into a read-only repo, but I wasn't able to find any other way to propose the fix.

Been fighting with the same issue for the whole day in my own project and this repo was the only open-source code for handling pongs with POCO websockets I was able to find :)

It appears you just need to add a FIN flag in order for the pong frame to be handled correctly. 
