### PR TITLE
Use -delete command of find instead of -exec rm

### DIFF
--- a/debian/loolwsd.cron.d
+++ b/debian/loolwsd.cron.d
@@ -1,1 +1,1 @@
-0 0 */1 * * root find /var/cache/loolwsd -type f -a -atime +10 -exec rm {} \;
+0 0 */1 * * root find /var/cache/loolwsd -type f -a -atime +10 -delete


### PR DESCRIPTION
Since the find command is called as root, it might be possible to delete arbitrary files if a filename contains a space.