### PR TITLE
Include missing dependencies for docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get upgrade -y
 # install LibreOffice run-time dependencies
 # install adduser, findutils, openssl and cpio that we need later
 # install an editor
-RUN apt-get -y install locales-all libpng16-16 fontconfig adduser cpio findutils nano libpocoxml50 libpocoutil50 libpoconetssl50 libpoconet50 libpocojson50 libpocofoundation50 libpococrypto50 libcap2-bin openssl inotify-tools procps
+RUN apt-get -y install locales-all libpng16-16 fontconfig adduser cpio findutils nano libpocoxml50 libpocoutil50 libpoconetssl50 libpoconet50 libpocojson50 libpocofoundation50 libpococrypto50 libcap2-bin openssl inotify-tools procps libxcb-shm0 libxcb-render0 libxrender1 libxext6
 
 # tdf#117557 - Add CJK Fonts to LibreOffice Online Docker Image
 RUN apt-get -y install fonts-wqy-zenhei fonts-wqy-microhei fonts-droid-fallback fonts-noto-cjk


### PR DESCRIPTION
See this gerrit issue: https://bugs.documentfoundation.org/show_bug.cgi?id=127750

I cannot create an account on your gerrit due to it constantly giving me `504 Gateway Time-out` error messages, so I submitted the PR here despite it clearly being stated this is read only. Hopefully someone will see this and merge it upstream so `libreoffice/online:master` docker image works again.