### PR TITLE
Upgrade HPA to autoscaling/v2 API

### DIFF
--- a/kubernetes/helm/libreoffice-online/templates/hpa.yaml
+++ b/kubernetes/helm/libreoffice-online/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.app.scaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Values.hpa.name }}
@@ -18,15 +18,19 @@ spec:
   maxReplicas: {{ .Values.global.app.scaling.max }}
   metrics:
 {{- if gt .Values.global.app.scaling.target.memory 1.0 }}  
-  - type: Resource
+  - type: Resource    
     resource:
       name: memory
-      targetAverageUtilization: {{ .Values.global.app.scaling.target.memory }}
+      target:
+        type: AverageValue
+        averageValue: {{ .Values.global.app.scaling.target.memory }}
 {{- end }}  
 {{- if gt .Values.global.app.scaling.target.cpu 1.0 }}      
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: {{ .Values.global.app.scaling.target.cpu }}      
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.global.app.scaling.target.cpu }}
 {{- end }}        
 {{- end }}


### PR DESCRIPTION
quick fix for current k8s using autoscaling/v2 instead of old autoscaling/v2beta